### PR TITLE
Changed code to correctly set SQLite3 type for Java String type.

### DIFF
--- a/compiler/src/main/java/com/contentful/vault/compiler/SqliteUtils.java
+++ b/compiler/src/main/java/com/contentful/vault/compiler/SqliteUtils.java
@@ -27,7 +27,7 @@ final class SqliteUtils {
 
   static String typeForClass(String className) {
     if (String.class.getName().equals(className)) {
-      return "STRING";
+      return "TEXT";
     } else if (Boolean.class.getName().equals(className)) {
       return "BOOL";
     } else if (Integer.class.getName().equals(className)) {

--- a/compiler/src/test/resources/ModelInjection.java
+++ b/compiler/src/test/resources/ModelInjection.java
@@ -12,7 +12,7 @@ public final class Test$AwesomeModel$$ModelHelper extends ModelHelper<Test.Aweso
   final List<FieldMeta> fields = new ArrayList<FieldMeta>();
 
   public Test$AwesomeModel$$ModelHelper() {
-    fields.add(FieldMeta.builder().setId("textField").setName("textField").setSqliteType("STRING").build());
+    fields.add(FieldMeta.builder().setId("textField").setName("textField").setSqliteType("TEXT").build());
     fields.add(FieldMeta.builder().setId("booleanField").setName("booleanField").setSqliteType("BOOL").build());
     fields.add(FieldMeta.builder().setId("integerField").setName("integerField").setSqliteType("INT").build());
     fields.add(FieldMeta.builder().setId("doubleField").setName("doubleField").setSqliteType("DOUBLE").build());
@@ -40,7 +40,7 @@ public final class Test$AwesomeModel$$ModelHelper extends ModelHelper<Test.Aweso
   public List<String> getCreateStatements(SpaceHelper spaceHelper) {
     List<String> list = new ArrayList<String>();
     for (String code : spaceHelper.getLocales()) {
-      list.add("CREATE TABLE `entry_y2lk$" + code + "` (`remote_id` STRING NOT NULL UNIQUE, `created_at` STRING NOT NULL, `updated_at` STRING, `textField` STRING, `booleanField` BOOL, `integerField` INT, `doubleField` DOUBLE, `mapField` BLOB, `arrayOfSymbols` BLOB);");
+      list.add("CREATE TABLE `entry_y2lk$" + code + "` (`remote_id` STRING NOT NULL UNIQUE, `created_at` STRING NOT NULL, `updated_at` STRING, `textField` TEXT, `booleanField` BOOL, `integerField` INT, `doubleField` DOUBLE, `mapField` BLOB, `arrayOfSymbols` BLOB);");
     }
     return list;
   }


### PR DESCRIPTION
For a project we ran into a problem with incorrect storing of numerical strings (in our case phone numbers). The framework uses the type 'STRING' if the object is of the class `java.class.String`. 'STRING' however is not a valid [SQLite type](https://www.sqlite.org/datatype3.html). The correct type for saving strings in SQLite is 'TEXT'. If the type is set invalidly SQLite will try and figure out which type it is, which goes wrong for numerical strings. 

Input: 020xxxxxxx
Expected outcome: 020xxxxxxx
Outcome: 20xxxxxxx

