### PR TITLE
fix: remove circular reference creation loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Version [2.1.1][unreleased] - (in development)
-- TBA
+- BugFix: circular dependencies on non asset links.
 
 ## Version [2.1.0]- 2016-11-10
 - Updating to newest Contentful Delivery Api SDK, adding limited support for sync in preview.

--- a/core/src/main/java/com/contentful/vault/LinkResolver.java
+++ b/core/src/main/java/com/contentful/vault/LinkResolver.java
@@ -95,13 +95,13 @@ final class LinkResolver {
       // Link target not found in cache, fetch from DB
       child = resourceForLink(link, locale);
       if (child != null) {
+        // Put into cache
+        cache.put(child.remoteId(), child);
+
         if (!linksToAsset) {
           // Resolve links for linked target
           resolveLinks(child, getHelperForEntry(child).getFields(), locale);
         }
-
-        // Put into cache
-        cache.put(child.remoteId(), child);
       }
     }
     return child;

--- a/tests-integration/src/test/java/com/contentful/vaultintegration/ArrayLinks.java
+++ b/tests-integration/src/test/java/com/contentful/vaultintegration/ArrayLinks.java
@@ -1,0 +1,44 @@
+package com.contentful.vaultintegration;
+
+import com.contentful.vault.Vault;
+import com.contentful.vaultintegration.lib.arraylinks.MultiLinksSpace;
+import com.contentful.vaultintegration.lib.arraylinks.Product;
+import com.contentful.vaultintegration.lib.arraylinks.Product$Fields;
+import com.contentful.vaultintegration.lib.arraylinks.Shop;
+
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class ArrayLinks extends BaseTest {
+
+  @Override protected void setupVault() {
+    vault = Vault.with(RuntimeEnvironment.application, MultiLinksSpace.class);
+  }
+
+  @Test public void testLinks() throws Exception {
+    // Initial
+    enqueueSync("arraylinks");
+    sync();
+
+    // fetch only one
+    final List<Product> all = vault.fetch(Product.class)
+        .where(Product$Fields.REMOTE_ID + " = ?", "2ZMtY36Lj2M204kesAs4CK")
+        .all();
+
+    assertThat(all.size()).isEqualTo(1);
+    final Product product = all.get(0);
+    assertThat(product.remoteId().equals("2ZMtY36Lj2M204kesAs4CK")).isTrue();
+
+    final Shop shop = product.shops().get(0);
+    assertThat(shop.name()).isEqualTo("Alexa");
+    assertThat(shop.products().size()).isEqualTo(6);
+    assertThat(shop.products().get(3).remoteId()).isEqualTo(product.remoteId());
+
+    assertThat(shop.products().get(2).shops().size()).isEqualTo(2);
+    assertThat(shop.products().get(2).shops().get(1).name()).isEqualTo("Rewe");
+  }
+}

--- a/tests-integration/src/test/java/com/contentful/vaultintegration/lib/arraylinks/MultiLinksSpace.java
+++ b/tests-integration/src/test/java/com/contentful/vaultintegration/lib/arraylinks/MultiLinksSpace.java
@@ -1,0 +1,11 @@
+package com.contentful.vaultintegration.lib.arraylinks;
+
+import com.contentful.vault.Space;
+
+@Space(
+    value = "kykc8h4zm12t",
+    models = {Product.class, Shop.class},
+    locales = "en-US"
+)
+public class MultiLinksSpace {
+}

--- a/tests-integration/src/test/java/com/contentful/vaultintegration/lib/arraylinks/Product.java
+++ b/tests-integration/src/test/java/com/contentful/vaultintegration/lib/arraylinks/Product.java
@@ -1,0 +1,22 @@
+package com.contentful.vaultintegration.lib.arraylinks;
+
+import com.contentful.vault.ContentType;
+import com.contentful.vault.Field;
+import com.contentful.vault.Resource;
+
+import java.util.List;
+
+@ContentType("product")
+public class Product extends Resource {
+  @Field String name;
+
+  @Field List<Shop> shops;
+
+  public String name() {
+    return name;
+  }
+
+  public List<Shop> shops() {
+    return shops;
+  }
+}

--- a/tests-integration/src/test/java/com/contentful/vaultintegration/lib/arraylinks/Shop.java
+++ b/tests-integration/src/test/java/com/contentful/vaultintegration/lib/arraylinks/Shop.java
@@ -1,0 +1,22 @@
+package com.contentful.vaultintegration.lib.arraylinks;
+
+import com.contentful.vault.ContentType;
+import com.contentful.vault.Field;
+import com.contentful.vault.Resource;
+
+import java.util.List;
+
+@ContentType("shop")
+public class Shop extends Resource {
+  @Field String name;
+
+  @Field List<Product> products;
+
+  public String name() {
+    return name;
+  }
+
+  public List<Product> products() {
+    return products;
+  }
+}

--- a/tests-integration/src/test/resources/arraylinks/initial.json
+++ b/tests-integration/src/test/resources/arraylinks/initial.json
@@ -1,0 +1,376 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "1c268NE7eYoMGamkAQqaca",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:53:25.989Z",
+        "updatedAt": "2017-08-15T13:55:43.659Z",
+        "revision": 3,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "product"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "🍅"
+        },
+        "shops": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "5O4RZBdPPicIeqEUaqUGmU"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "4YRwJ0j2L6GACSSE2Y2Gqg"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "QKmnd0RGmc6UkIQQ0qUac",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:54:46.663Z",
+        "updatedAt": "2017-08-15T13:55:09.618Z",
+        "revision": 2,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "product"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "👽"
+        },
+        "shops": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "645eBLi2GWKekOgaqsMWA6"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "645eBLi2GWKekOgaqsMWA6",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:54:50.025Z",
+        "updatedAt": "2017-08-15T13:54:50.025Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "shop"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "Penny"
+        },
+        "products": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "QKmnd0RGmc6UkIQQ0qUac"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "4YRwJ0j2L6GACSSE2Y2Gqg",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:54:14.774Z",
+        "updatedAt": "2017-08-15T13:54:14.774Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "shop"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "Rewe"
+        },
+        "products": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "1c268NE7eYoMGamkAQqaca"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "1c268NE7eYoMGamkAQqaca"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "1c268NE7eYoMGamkAQqaca"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "5O4RZBdPPicIeqEUaqUGmU",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:53:48.189Z",
+        "updatedAt": "2017-08-15T13:53:48.189Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "shop"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "Alexa"
+        },
+        "products": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "2ZMtY36Lj2M204kesAs4CK"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "5mCJUNJ3bycq4sU4Ie6G0c"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "1c268NE7eYoMGamkAQqaca"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "2ZMtY36Lj2M204kesAs4CK"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "5mCJUNJ3bycq4sU4Ie6G0c"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "2G4yweTBVeMsyQCoQC0WmY"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "2G4yweTBVeMsyQCoQC0WmY",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:53:07.230Z",
+        "updatedAt": "2017-08-15T13:53:07.230Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "product"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "🥒"
+        },
+        "shops": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "5O4RZBdPPicIeqEUaqUGmU"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "5mCJUNJ3bycq4sU4Ie6G0c",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:52:12.284Z",
+        "updatedAt": "2017-08-15T13:52:12.284Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "product"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "🍐"
+        },
+        "shops": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "5O4RZBdPPicIeqEUaqUGmU"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "2ZMtY36Lj2M204kesAs4CK",
+        "type": "Entry",
+        "createdAt": "2017-08-15T13:51:50.244Z",
+        "updatedAt": "2017-08-15T13:51:50.244Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "product"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "🍎"
+        },
+        "shops": {
+          "en-US": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "5O4RZBdPPicIeqEUaqUGmU"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "nextSyncUrl": "https://cdn.contentful.com/spaces/kykc8h4zm12t/sync?sync_token=w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCqsOcHsO0woBpw5FFw6nDu8O9CS0DUU_ClcONbWHDiMObEGrDqMKaw53DrEzCkn3ChMKEF3Zew5cCwp1Vw4oxwojDk3YyNxjDmkDCjRMpw7zDnMKHU8OUw5ZMwqpvVU0"
+}

--- a/tests-integration/src/test/resources/arraylinks/space.json
+++ b/tests-integration/src/test/resources/arraylinks/space.json
@@ -1,0 +1,15 @@
+{
+  "sys": {
+    "type": "Space",
+    "id": "kykc8h4zm12t"
+  },
+  "name": "Indirect Circular References",
+  "locales": [
+    {
+      "code": "en-US",
+      "default": true,
+      "name": "U.S. English",
+      "fallbackCode": null
+    }
+  ]
+}

--- a/tests-integration/src/test/resources/arraylinks/types.json
+++ b/tests-integration/src/test/resources/arraylinks/types.json
@@ -1,0 +1,110 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 2,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "product",
+        "type": "ContentType",
+        "createdAt": "2017-08-15T13:46:27.919Z",
+        "updatedAt": "2017-08-15T13:52:44.380Z",
+        "revision": 3
+      },
+      "displayField": "name",
+      "name": "Product",
+      "description": "A product in a shop",
+      "fields": [
+        {
+          "id": "name",
+          "name": "name",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "shops",
+          "name": "shops",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "shop"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "kykc8h4zm12t"
+          }
+        },
+        "id": "shop",
+        "type": "ContentType",
+        "createdAt": "2017-08-15T13:47:07.542Z",
+        "updatedAt": "2017-08-15T13:52:34.917Z",
+        "revision": 2
+      },
+      "displayField": "name",
+      "name": "Shop",
+      "description": "A shop of producs",
+      "fields": [
+        {
+          "id": "name",
+          "name": "name",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "products",
+          "name": "products",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "product"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is done by putting the fetched objects from the DB to the local cache, before trying to resolve their links.

fixes #127