### PR TITLE
Support of private fields in Resource

### DIFF
--- a/compiler/src/test/java/com/contentful/vault/compiler/ContentTypeTest.java
+++ b/compiler/src/test/java/com/contentful/vault/compiler/ContentTypeTest.java
@@ -35,7 +35,6 @@ public class ContentTypeTest {
         "import com.contentful.vault.ContentType;",
         "import com.contentful.vault.Field;",
         "import com.contentful.vault.Resource;",
-        "import com.contentful.vault.SpaceHelper;",
         "import java.util.List;",
         "import java.util.Map;",
         "class Test {",
@@ -51,6 +50,10 @@ public class ContentTypeTest {
         "    @Field List<Asset> arrayOfAssets;",
         "    @Field List<AwesomeModel> arrayOfModels;",
         "    @Field List<String> arrayOfSymbols;",
+        "    @Field private String privateField;",
+        "    @Field private String privateFluentField;",
+        "    public void setPrivateField(String privateField) { this.privateField = privateField; }",
+        "    public void privateFluentField(String privateFluentField) { this.privateFluentField = privateFluentField; }",
         "  }",
         "}"
     ));

--- a/compiler/src/test/java/com/contentful/vault/compiler/FieldTest.java
+++ b/compiler/src/test/java/com/contentful/vault/compiler/FieldTest.java
@@ -132,7 +132,7 @@ public class FieldTest {
     assert_().about(javaSource()).that(source)
         .processedWith(processors())
         .failsToCompile()
-        .withErrorContaining("@Field elements must not be private. (Test.foo)");
+        .withErrorContaining("@Field private elements must have public setter methods. (Test.foo)");
   }
 
   @Test public void testInvalidListType() throws Exception {

--- a/compiler/src/test/resources/ModelInjection.java
+++ b/compiler/src/test/resources/ModelInjection.java
@@ -24,6 +24,8 @@ public final class Test$AwesomeModel$$ModelHelper extends ModelHelper<Test.Aweso
     fields.add(FieldMeta.builder().setId("arrayOfModels").setName("arrayOfModels").setArrayType("Test.AwesomeModel").build());
     fields.add(FieldMeta.builder().setId("arrayOfSymbols").setName("arrayOfSymbols").setSqliteType(
         "BLOB").setArrayType("java.lang.String").build());
+    fields.add(FieldMeta.builder().setId("privateField").setName("privateField").setSetter("setPrivateField").setSqliteType("TEXT").build());
+    fields.add(FieldMeta.builder().setId("privateFluentField").setName("privateFluentField").setSetter("privateFluentField").setSqliteType("TEXT").build());
   }
 
   @Override
@@ -40,7 +42,7 @@ public final class Test$AwesomeModel$$ModelHelper extends ModelHelper<Test.Aweso
   public List<String> getCreateStatements(SpaceHelper spaceHelper) {
     List<String> list = new ArrayList<String>();
     for (String code : spaceHelper.getLocales()) {
-      list.add("CREATE TABLE `entry_y2lk$" + code + "` (`remote_id` STRING NOT NULL UNIQUE, `created_at` STRING NOT NULL, `updated_at` STRING, `textField` TEXT, `booleanField` BOOL, `integerField` INT, `doubleField` DOUBLE, `mapField` BLOB, `arrayOfSymbols` BLOB);");
+      list.add("CREATE TABLE `entry_y2lk$" + code + "` (`remote_id` STRING NOT NULL UNIQUE, `created_at` STRING NOT NULL, `updated_at` STRING, `textField` TEXT, `booleanField` BOOL, `integerField` INT, `doubleField` DOUBLE, `mapField` BLOB, `arrayOfSymbols` BLOB, `privateField` TEXT, `privateFluentField` TEXT);");
     }
     return list;
   }
@@ -56,6 +58,8 @@ public final class Test$AwesomeModel$$ModelHelper extends ModelHelper<Test.Aweso
     result.doubleField = cursor.getDouble(6);
     result.mapField = fieldFromBlob(HashMap.class, cursor, 7);
     result.arrayOfSymbols = fieldFromBlob(ArrayList.class, cursor, 8);
+    result.setPrivateField(cursor.getString(9));
+    result.privateFluentField(cursor.getString(10));
     return result;
   }
 
@@ -91,6 +95,12 @@ public final class Test$AwesomeModel$$ModelHelper extends ModelHelper<Test.Aweso
     }
     else if ("arrayOfSymbols".equals(name)) {
       resource.arrayOfSymbols = (List<String>) value;
+    }
+    else if ("privateField".equals(name)) {
+      resource.setPrivateField((String) value);
+    }
+    else if ("privateFluentField".equals(name)) {
+      resource.privateFluentField((String) value);
     }
     else {
       return false;

--- a/core/src/main/java/com/contentful/vault/FieldMeta.java
+++ b/core/src/main/java/com/contentful/vault/FieldMeta.java
@@ -23,6 +23,8 @@ public final class FieldMeta {
 
   private final String name;
 
+  private final String setter;
+
   private final TypeMirror type;
 
   private final String sqliteType;
@@ -34,6 +36,7 @@ public final class FieldMeta {
   FieldMeta(Builder builder) {
     this.id = builder.id;
     this.name = builder.name;
+    this.setter = builder.setter;
     this.type = builder.type;
     this.sqliteType = builder.sqliteType;
     this.linkType = builder.linkType;
@@ -46,6 +49,10 @@ public final class FieldMeta {
 
   public String name() {
     return name;
+  }
+
+  public String setter() {
+    return setter;
   }
 
   public TypeMirror type() {
@@ -100,6 +107,7 @@ public final class FieldMeta {
     String sqliteType;
     String linkType;
     String arrayType;
+    String setter;
 
     public Builder setId(String id) {
       this.id = id;
@@ -108,6 +116,11 @@ public final class FieldMeta {
 
     public Builder setName(String name) {
       this.name = name;
+      return this;
+    }
+
+    public Builder setSetter(String setter) {
+      this.setter = setter;
       return this;
     }
 


### PR DESCRIPTION
Today, when we build a Model we need to have **public** fields because the ModelHelper generated references fields directly.

I have change the behavior to allow user to use private fields if any setter exists, which is more standard according to a the JavaBeans specification.

Example :

```
@ContentType("cat")
public class MyModel extends Resource {
  @Field public String publicField;
  @Field private String privateField;
 
  public void setPrivateField(String privateField) {
    this.privateField = privateField;
  }
}
```

will produce a ModelHelper containing
```
public MyModel fromCursor(Cursor cursor) {
    MyModel result = new MyModel();
    setContentType(result, "cid");
    result.publicField = cursor.getString(3);
    result.setPrivateField(cursor.getString(4);
    return result;
  }
```
